### PR TITLE
CertAuth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For the fast version (this doesn't allow to send input to the command):
 ```go
 import "github.com/masterzen/winrm/winrm"
 
-client := winrm.NewClient("localhost", "Administrator", "secret", winrm.BasicAuth)
+client := winrm.NewClient("localhost", "Administrator", "secret")
 client.Run("ipconfig /all", os.Stdout, os.Stderr)
 ```
 
@@ -89,7 +89,7 @@ or
 ```go
 import "github.com/masterzen/winrm/winrm"
 
-client := winrm.NewClient("localhost", "Administrator", "secret", winrm.BasicAuth)
+client := winrm.NewClient("localhost", "Administrator", "secret")
 stdout, stderr, _ := client.RunWithString("ipconfig /all", "")
 println(stdout)
 println(stderr)
@@ -108,7 +108,7 @@ import (
 
 stdin := bytes.NewBufferString("ipconfig /all")
 
-client := winrm.NewClient("localhost", "Administrator", "secret", winrm.BasicAuth)
+client := winrm.NewClient("localhost", "Administrator", "secret")
 shell, err := client.CreateShell()
 if err != nil {
   fmt.Printf("Impossible to create shell %s\n", err)
@@ -144,7 +144,7 @@ certBytes := []byte(`CERTIFICATE`)
 
 keyBytes := []byte(`KEY`)
 
-client, err := winrm.NewClient(&winrm.Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Insecure: true, Cert: certBytes, Key: keyBytes}, "", "", winrm.CertAuth)
+client, err := winrm.NewClient(&winrm.Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Insecure: true, Cert: certBytes, Key: keyBytes}, "", "")
 shell, err := client.CreateShell()
 if err != nil {
   fmt.Printf("Impossible to create shell %s\n", err)

--- a/winrm.go
+++ b/winrm.go
@@ -37,7 +37,6 @@ func main() {
 		cacert   string
 		cert     string
 		key      string
-		auth     string
 	)
 
 	flag.StringVar(&hostname, "hostname", "localhost", "winrm host")
@@ -49,7 +48,6 @@ func main() {
 	flag.StringVar(&cacert, "cacert", "", "CA certificate to use")
 	flag.StringVar(&cert, "cert", "", "Cert")
 	flag.StringVar(&key, "key", "", "Key")
-	flag.StringVar(&auth, "authtype", "basic", "Auth Type")
 
 	flag.Parse()
 
@@ -84,7 +82,7 @@ func main() {
 	}
 
 	cmd = flag.Arg(0)
-	client, err := winrm.NewClient(&winrm.Endpoint{Host: hostname, Port: port, HTTPS: https, Insecure: insecure, CACert: &CAcertBytes, Cert: &certBytes, Key: &keyBytes}, user, pass, winrm.AuthType(auth))
+	client, err := winrm.NewClient(&winrm.Endpoint{Host: hostname, Port: port, HTTPS: https, Insecure: insecure, CACert: &CAcertBytes, Cert: &certBytes, Key: &keyBytes}, user, pass)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/winrm.go
+++ b/winrm.go
@@ -35,6 +35,9 @@ func main() {
 		https    bool
 		insecure bool
 		cacert   string
+		cert     string
+		key      string
+		auth     string
 	)
 
 	flag.StringVar(&hostname, "hostname", "localhost", "winrm host")
@@ -44,22 +47,44 @@ func main() {
 	flag.BoolVar(&https, "https", false, "use https")
 	flag.BoolVar(&insecure, "insecure", false, "skip SSL validation")
 	flag.StringVar(&cacert, "cacert", "", "CA certificate to use")
+	flag.StringVar(&cert, "cert", "", "Cert")
+	flag.StringVar(&key, "key", "", "Key")
+	flag.StringVar(&auth, "authtype", "basic", "Auth Type")
+
 	flag.Parse()
 
-	var certBytes []byte
 	var err error
-	if cacert != "" {
-		certBytes, err = ioutil.ReadFile(cacert)
+	var certBytes, keyBytes []byte
+	if cert != "" && key != "" {
+		certBytes, err = ioutil.ReadFile(cert)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		keyBytes, err = ioutil.ReadFile(key)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 	} else {
 		certBytes = nil
+		keyBytes = nil
+	}
+
+	var CAcertBytes []byte
+	if cacert != "" {
+		CAcertBytes, err = ioutil.ReadFile(cacert)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	} else {
+		CAcertBytes = nil
 	}
 
 	cmd = flag.Arg(0)
-	client, err := winrm.NewClient(&winrm.Endpoint{Host: hostname, Port: port, HTTPS: https, Insecure: insecure, CACert: &certBytes}, user, pass)
+	client, err := winrm.NewClient(&winrm.Endpoint{Host: hostname, Port: port, HTTPS: https, Insecure: insecure, CACert: &CAcertBytes, Cert: &certBytes, Key: &keyBytes}, user, pass, winrm.AuthType(auth))
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/winrm/client_test.go
+++ b/winrm/client_test.go
@@ -3,25 +3,173 @@ package winrm
 import (
 	"github.com/masterzen/winrm/soap"
 	. "gopkg.in/check.v1"
+	"launchpad.net/gwacl/fork/tls"
 )
 
+var key = `
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCc3TmlGZVwcwgK
+qS6V1FmyGuNbeSG657pArXvVAeKq8usLXjPr6RmjIRzV7soS4PQdqSIVtSUBAFlk
+2S0YLMGuPXufwwaxeIgW+qTJLP9oF6U13NIDcswIM/2EvdgaBfjNO71KoON3qzOW
+KmuTlTL9ifyF+9sLiR2FWnXq408u5B4/1aAe9xOel/2AyzGjiesQt1Q1MsvKFs3d
+/1fxuf550jV8krVKDRVFZyARZfZ2qT02hxqqp0j7H0k06KQ8ljfP6mx0B3Nx0M71
+TQ6Ni+HFIIiuO448cu6fZw97O83qGkNDmXV130ZwlKXeby6E8CBK+JwmtSWd0w+B
++ex7oGGJAgMBAAECggEAL5mV93qW9WOCqjGCeGbSvRAZs9VDHgNZamz6ab3DuZoz
+JuT0Hn9Cj1Tp+iUW3rmyehmrxSiNzQr9FXQtketq7mOr0uQMcOgha8+tF3r3GfAq
+6vhSJke8kDSuloxBOkxbnnOlUjMWM2cZJVVEBam9qmAn58RwSMTX13KG27sUeSa4
+Lvl0SiCfxl99NBHHNXWutJIuBWP+dCejbiK0xb7thuIBLN4T50JHAfMExeU51YmD
+OUrwYVTU1FozeJcQuQ5cA3fBkfIzhrFmn16gGUKdy9L1UzBfU+skVxycXLr/2AtI
+gO+W33tHzxuPluRYBQNgfxxnv9ajUc/2EjztGXLJLQKBgQDQBbC5bMr8Y3NcB+6V
+lNZykniPBwrTD+4lGBh30rQKeKd5mNMHadPVORBK/FliSvioDS8RwtKz8Iq5HGTh
+5wRW2+5cytznHoPH/s3AxxA3Jw0A4xt3/+xFsBQITRoB3IxptffRak4uQsWR46RM
+l8ItBZ3FvskTQTWULQ/M4XvpZwKBgQDBCv75hXQW1P6cMzHcs4MUeADe2qM+LHRh
+y7So/oyZMJvlukhM6gR385jzRRcWH7n+5o7dLGaVJ6I5Hg5RMbspIfgOqRrTD/o5
+yZF5XSYw2UFhldYMlADHuSF5jM5puv/odQEykjasMo3eYnhod7k9UksOrrECdUnf
+99hActFXjwKBgQCT9vg1bIUV8Udk9t9l1nCTHkxSsBeq+XHTQMhmsqENsbSucV3p
+sATVbbmBHO4XVGx6XKZWY9Wr2DVUZjX72W7kuZtatZFbdAEYiM2hifamxEgjkWdA
+e/F7wDr/jJgrKs1Vg/G6K3tgvG37z4hWUrvzekM3HPW5lHCf7U2H1ftlkQKBgBvb
+K1n0UQEucSM3G/3eBY9BldaStDW3kn++Nm6gdMdyRTzMObynlEd+5lZMZP1zTJKk
+0H7H9nGVi4o0dRpwU7KmzTXIXy+PwarvFEfwEh/Aaffb+ExOWyJ264avs+V774uq
+vqZ+hNcqYGBz0y44AIoBwwT2XmKdbDCegh0itGSvAoGAGWgwqJ4pCEmW/EAMjg8Q
+TfiXBqrBINgPISGIV2ASTIHb4n2k2yEsTJiODk85M00DtkCjqWR8fa/F8N01Rwnf
+nJH+lDaWkqbWyYanRl2LgC6vuHcu1d5GjxfCzGgMnBhXi7YZjPaTZaDC5poaTyFW
+S5GRL8NLTmLBxDYXWzcwlTw=
+-----END PRIVATE KEY-----
+`[1:]
+
+var cert = `
+-----BEGIN CERTIFICATE-----
+MIIDGzCCAgMCAgPoMA0GCSqGSIb3DQEBBQUAMCgxJjAkBgNVBAMUHW1hYXNjb250
+cm9sbGVyQE1hYXNDb250cm9sbGVyMB4XDTE1MDcxMDEzMjY0N1oXDTI1MDcwNzEz
+MjY0N1owKDEmMCQGA1UEAxQdbWFhc2NvbnRyb2xsZXJATWFhc0NvbnRyb2xsZXIw
+ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCc3TmlGZVwcwgKqS6V1Fmy
+GuNbeSG657pArXvVAeKq8usLXjPr6RmjIRzV7soS4PQdqSIVtSUBAFlk2S0YLMGu
+PXufwwaxeIgW+qTJLP9oF6U13NIDcswIM/2EvdgaBfjNO71KoON3qzOWKmuTlTL9
+ifyF+9sLiR2FWnXq408u5B4/1aAe9xOel/2AyzGjiesQt1Q1MsvKFs3d/1fxuf55
+0jV8krVKDRVFZyARZfZ2qT02hxqqp0j7H0k06KQ8ljfP6mx0B3Nx0M71TQ6Ni+HF
+IIiuO448cu6fZw97O83qGkNDmXV130ZwlKXeby6E8CBK+JwmtSWd0w+B+ex7oGGJ
+AgMBAAGjVDBSMDgGA1UdEQQxMC+gLQYKKwYBBAGCNxQCA6AfDB1tYWFzY29udHJv
+bGxlckBNYWFzQ29udHJvbGxlcjAWBgNVHSUBAf8EDDAKBggrBgEFBQcDAjANBgkq
+hkiG9w0BAQUFAAOCAQEAeoK0Ndddv346JBZFWpsLIeygxtFLMtKa3A4DMYfTO2Ht
+STiEKe4027ptQ/uMkYVEHHHD/Jr3Nz0/qOciGu7r7Q+rDQlJRyC4VgNhieniSjck
+8coWjg65xuZHh/SePQK9eatOHTYQIU4CoQhk0kPtNdsF70iaE8DqsFT30gEEYHnG
+BHTNtF0jH8vw32u0fYhfxYZSaQEycQ5bT46IHnU2RZMYSNiiSf9jj8kHG3s9Xu2r
+RuoV7MsL0ju6DgUydp40rYGFL3lpzlSvPKATHB6zcOE9pB8GD3z7Lp4b4Anz6Jlu
+QkGuzNBHsEJlM3/pXqUpnP6kvlwZfIhQaefNnYhnmQ==
+-----END CERTIFICATE-----
+`[1:]
+
+var keyBytes = []byte(key)
+var certBytes = []byte(cert)
+
 func (s *WinRMSuite) TestNewClient(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
 
 	c.Assert(err, IsNil)
 	c.Assert(client.url, Equals, "http://localhost:5985/wsman")
 	c.Assert(client.username, Equals, "Administrator")
 	c.Assert(client.password, Equals, "v3r1S3cre7")
+	c.Assert(client.authtype, Equals, BasicAuth)
+}
+
+func (s *WinRMSuite) TestNewClientInvalidTransport(c *C) {
+	_, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "", "", "Auth")
+
+	c.Assert(err, ErrorMatches, "Invalid transport type: Auth")
+}
+
+func (s *WinRMSuite) TestNewClientBasicAuthNoUserAndPassword(c *C) {
+	var basicAuthTests = []struct {
+		username string
+		password string
+	}{
+		{"", ""},
+		{"Administrator", ""},
+		{"", "v3r1S3cre7"},
+	}
+
+	for _, k := range basicAuthTests {
+		_, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, k.username, k.password, BasicAuth)
+
+		c.Assert(err, ErrorMatches, "BasicAuth needs username and password")
+	}
+}
+
+func (s *WinRMSuite) TestNewClientCertAuth(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+
+	c.Assert(err, IsNil)
+	c.Assert(client.url, Equals, "https://localhost:5986/wsman")
+	c.Assert(client.username, Equals, "")
+	c.Assert(client.password, Equals, "")
+	c.Assert(client.useHTTPS, Equals, true)
+	c.Assert(client.authtype, Equals, CertAuth)
+
+	transport := client.transport.TLSClientConfig.Certificates
+
+	certPool, err := tls.X509KeyPair(certBytes, keyBytes)
+
+	c.Assert(err, IsNil)
+
+	c.Assert(transport[0].Certificate, DeepEquals, certPool.Certificate)
+
+	c.Assert(transport[0].PrivateKey, DeepEquals, certPool.PrivateKey)
+
+}
+
+func (s *WinRMSuite) TestNewClientCertAuthInvalidProtocol(c *C) {
+	_, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: false, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+
+	c.Assert(err, ErrorMatches, "Invalid protocol for this transport type \\(CertAuth\\). Expected https")
+}
+
+func (s *WinRMSuite) TestNewClientCertAuthEmptyCertAndKeyFailure(c *C) {
+	fake := []byte("Fakeinput")
+	var certAuthTests = []struct {
+		cert *[]byte
+		key  *[]byte
+	}{
+		{nil, nil},
+		{&fake, nil},
+		{nil, &fake},
+	}
+
+	for _, k := range certAuthTests {
+		_, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: k.cert, Key: k.key}, "", "", CertAuth)
+
+		c.Assert(err, ErrorMatches, "CertAuth needs certificate and key")
+	}
+}
+
+func (s *WinRMSuite) TestNewClientCertAuthParseKeyPairFailure(c *C) {
+	invalid_key := []byte("AAA")
+	_, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &invalid_key}, "", "", CertAuth)
+
+	c.Assert(err, ErrorMatches, "Error parsing keypair: crypto/tls: failed to parse key PEM data")
 }
 
 func (s *WinRMSuite) TestClientCreateShell(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
 	c.Assert(err, IsNil)
 	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
 		c.Assert(message.String(), Contains, "http://schemas.xmlsoap.org/ws/2004/09/transfer/Create")
 		return createShellResponse, nil
 	}
 
-	shell, _ := client.CreateShell()
+	shell, err := client.CreateShell()
+	c.Assert(err, IsNil)
+	c.Assert(shell.ShellId, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
+}
+
+func (s *WinRMSuite) TestClientCreateShellCertAuth(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+	c.Assert(err, IsNil)
+	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
+		c.Assert(message.String(), Contains, "http://schemas.xmlsoap.org/ws/2004/09/transfer/Create")
+		return createShellResponse, nil
+	}
+
+	shell, err := client.CreateShell()
+	c.Assert(err, IsNil)
 	c.Assert(shell.ShellId, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
 }

--- a/winrm/command_test.go
+++ b/winrm/command_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *WinRMSuite) TestExecuteCommand(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -48,7 +48,7 @@ func (s *WinRMSuite) TestExecuteCommand(c *C) {
 }
 
 func (s *WinRMSuite) TestStdinCommand(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -81,7 +81,7 @@ func (s *WinRMSuite) TestStdinCommand(c *C) {
 }
 
 func (s *WinRMSuite) TestExecuteCommandCertAuth(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -119,7 +119,7 @@ func (s *WinRMSuite) TestExecuteCommandCertAuth(c *C) {
 }
 
 func (s *WinRMSuite) TestStdinCommandCertAuth(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}

--- a/winrm/command_test.go
+++ b/winrm/command_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *WinRMSuite) TestExecuteCommand(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -36,7 +36,9 @@ func (s *WinRMSuite) TestExecuteCommand(c *C) {
 		}
 	}
 
-	command, _ := shell.Execute("ipconfig /all")
+	command, err := shell.Execute("ipconfig /all")
+	c.Assert(err, IsNil)
+
 	var stdout, stderr bytes.Buffer
 	go io.Copy(&stdout, command.Stdout)
 	go io.Copy(&stderr, command.Stderr)
@@ -46,7 +48,7 @@ func (s *WinRMSuite) TestExecuteCommand(c *C) {
 }
 
 func (s *WinRMSuite) TestStdinCommand(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -67,7 +69,80 @@ func (s *WinRMSuite) TestStdinCommand(c *C) {
 		}
 	}
 
-	command, _ := shell.Execute("ipconfig /all")
+	command, err := shell.Execute("ipconfig /all")
+	c.Assert(err, IsNil)
+
+	command.Stdin.Write([]byte("standard input"))
+	// slurp output from command
+	var outWriter, errWriter bytes.Buffer
+	go io.Copy(&outWriter, command.Stdout)
+	go io.Copy(&errWriter, command.Stderr)
+	command.Wait()
+}
+
+func (s *WinRMSuite) TestExecuteCommandCertAuth(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+	c.Assert(err, IsNil)
+
+	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
+	count := 0
+	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
+		switch count {
+		case 0:
+			{
+				c.Assert(message.String(), Contains, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command")
+				count = 1
+				return executeCommandResponse, nil
+			}
+		case 1:
+			{
+				c.Assert(message.String(), Contains, "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive")
+				count = 2
+				return outputResponse, nil
+			}
+		default:
+			{
+				return doneCommandResponse, nil
+			}
+		}
+	}
+
+	command, err := shell.Execute("ipconfig /all")
+	c.Assert(err, IsNil)
+
+	var stdout, stderr bytes.Buffer
+	go io.Copy(&stdout, command.Stdout)
+	go io.Copy(&stderr, command.Stderr)
+	command.Wait()
+	c.Assert(stdout.String(), Equals, "That's all folks!!!")
+	c.Assert(stderr.String(), Equals, "This is stderr, I'm pretty sure!")
+}
+
+func (s *WinRMSuite) TestStdinCommandCertAuth(c *C) {
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+	c.Assert(err, IsNil)
+
+	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
+	count := 0
+	client.http = func(client *Client, message *soap.SoapMessage) (string, error) {
+		if strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Send") {
+			c.Assert(message.String(), Contains, "c3RhbmRhcmQgaW5wdXQ=")
+			return "", nil
+		} else {
+			if strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Command") {
+				return executeCommandResponse, nil
+			} else if count != 1 && strings.Contains(message.String(), "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Receive") {
+				count = 1
+				return outputResponse, nil
+			} else {
+				return doneCommandResponse, nil
+			}
+		}
+	}
+
+	command, err := shell.Execute("ipconfig /all")
+	c.Assert(err, IsNil)
+
 	command.Stdin.Write([]byte("standard input"))
 	// slurp output from command
 	var outWriter, errWriter bytes.Buffer

--- a/winrm/endpoint.go
+++ b/winrm/endpoint.go
@@ -8,6 +8,8 @@ type Endpoint struct {
 	HTTPS    bool
 	Insecure bool
 	CACert   *[]byte
+	Key      *[]byte
+	Cert     *[]byte
 }
 
 func (ep *Endpoint) url() string {

--- a/winrm/http.go
+++ b/winrm/http.go
@@ -3,7 +3,7 @@ package winrm
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
+	"launchpad.net/gwacl/fork/http"
 	"strings"
 
 	"github.com/masterzen/winrm/soap"
@@ -42,7 +42,16 @@ func Http_post(client *Client, request *soap.SoapMessage) (response string, err 
 		return
 	}
 	req.Header.Set("Content-Type", soapXML+";charset=UTF-8")
-	req.SetBasicAuth(client.username, client.password)
+
+	if client.authtype == BasicAuth {
+		req.SetBasicAuth(client.username, client.password)
+	} else if client.authtype == CertAuth {
+		req.Header.Add("Authorization", "http://schemas.dmtf.org/wbem/wsman/1/wsman/secprofile/https/mutual")
+	} else {
+		err = fmt.Errorf("Invalid transport: %s", client.authtype)
+		return
+	}
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		err = fmt.Errorf("unknown error %s", err)

--- a/winrm/http_test.go
+++ b/winrm/http_test.go
@@ -53,7 +53,7 @@ func (s *WinRMSuite) TestHttpRequest(c *C) {
 	ts.Start()
 	defer ts.Close()
 
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "test", "test", BasicAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "test", "test")
 	c.Assert(err, IsNil)
 	shell, err := client.CreateShell()
 	if err != nil {
@@ -75,7 +75,7 @@ func (s *WinRMSuite) TestHttpRequestCertAuth(c *C) {
 	ts.StartTLS()
 	defer ts.Close()
 
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Insecure: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Insecure: true, Cert: &certBytes, Key: &keyBytes}, "", "")
 	c.Assert(err, IsNil)
 	shell, err := client.CreateShell()
 	if err != nil {

--- a/winrm/http_test.go
+++ b/winrm/http_test.go
@@ -53,7 +53,29 @@ func (s *WinRMSuite) TestHttpRequest(c *C) {
 	ts.Start()
 	defer ts.Close()
 
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "test", "test")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "test", "test", BasicAuth)
+	c.Assert(err, IsNil)
+	shell, err := client.CreateShell()
+	if err != nil {
+		c.Fatalf("Can't create shell %s", err)
+	}
+	c.Assert(shell.ShellId, Equals, "67A74734-DD32-4F10-89DE-49A060483810")
+}
+
+func (s *WinRMSuite) TestHttpRequestCertAuth(c *C) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/soap+xml")
+		w.Write([]byte(response))
+	}))
+	l, err := net.Listen("tcp", "127.0.0.1:5986")
+	if err != nil {
+		c.Fatalf("Can't listen %s", err)
+	}
+	ts.Listener = l
+	ts.StartTLS()
+	defer ts.Close()
+
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5986, HTTPS: true, Insecure: true, Cert: &certBytes, Key: &keyBytes}, "", "", CertAuth)
 	c.Assert(err, IsNil)
 	shell, err := client.CreateShell()
 	if err != nil {

--- a/winrm/shell_test.go
+++ b/winrm/shell_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -27,7 +27,7 @@ func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
 }
 
 func (s *WinRMSuite) TestShellCloseResponse(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}

--- a/winrm/shell_test.go
+++ b/winrm/shell_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}
@@ -27,7 +27,7 @@ func (s *WinRMSuite) TestShellExecuteResponse(c *C) {
 }
 
 func (s *WinRMSuite) TestShellCloseResponse(c *C) {
-	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7")
+	client, err := NewClient(&Endpoint{Host: "localhost", Port: 5985}, "Administrator", "v3r1S3cre7", BasicAuth)
 	c.Assert(err, IsNil)
 
 	shell := &Shell{client: client, ShellId: "67A74734-DD32-4F10-89DE-49A060483810"}


### PR DESCRIPTION
- Added CertAuth support 
- Added tests for CertAuth and one test for BasicAuth 
- Modified README.md with an example using CertAuth and how to use it on the command-line

Note: When the SSL certificate is generated for winRM the UPN extension must not be marked as critical because it can not be validated by GO.
